### PR TITLE
Release 1.3.2: Fix incorrect timestamp handling in license validator

### DIFF
--- a/BridgefySDK.podspec
+++ b/BridgefySDK.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name             = 'BridgefySDK'
-  s.version          = '1.3.1'
+  s.version          = '1.3.2'
   s.summary          = 'Make your mobile app work without the Internet.'
   s.description      = 'The Bridgefy SDK is as versatile as you need it to be. Hundreds of millions of people lose access to the Internet every day, but they still need to use mobile apps. Open your mobile app to immense new markets that are waiting to use gaming, messaging, education, and payments apps, but can’t because of lack of an Internet connection.'
   s.homepage         = 'https://bridgefy.me/sdk/'
   s.license          = { :type => 'Commercial', :file => 'LICENSE.md' }
   s.author           = { 'Bridgefy' => 'contact@bridgefy.me' }
   s.platform         = :ios, '13.0'
-  s.source           = { :http => 'https://github.com/bridgefy/sdk-ios/releases/download/1.3.1/BridgefySDK.xcframework.zip' }
+  s.source           = { :http => 'https://github.com/bridgefy/sdk-ios/releases/download/1.3.2/BridgefySDK.xcframework.zip' }
   s.xcconfig     =  { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/BridgefySDK/"' }
   s.requires_arc = true
   s.source_files = 'BridgefySDK.xcframework/ios-arm64/BridgefySDK.framework/Headers/*.{h}'

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "BridgefySDK",
-            url: "https://github.com/bridgefy/sdk-ios/releases/download/1.3.1/BridgefySDK.xcframework.zip",
-            checksum: "8fe440f46c896cfe1b4e7e156a40a5685e8460a708feeca103a4b509dfa0a619"
+            url: "https://github.com/bridgefy/sdk-ios/releases/download/1.3.2/BridgefySDK.xcframework.zip",
+            checksum: "98c6ac14c75fead5b8fff83197d9e3ccd2602d51453a39f8b5dc9c07b98d37fc"
         )
     ]
 )


### PR DESCRIPTION
This release fixes an issue in the license validator caused by inconsistent date parsing from the server.

Previously, the DateFormatter relied on the system’s default calendar, locale, and timezone, which could lead to incorrect timestamp interpretation depending on the user’s regional settings. This resulted in invalid license validation in some environments.